### PR TITLE
Update to enable use in GAP release system

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/build_cygwin_gap_release.yml
+++ b/.github/workflows/build_cygwin_gap_release.yml
@@ -1,41 +1,38 @@
+name: GAP Windows release
+
 # Based on https://github.com/mit-plv/fiat-crypto/blob/master/.github/workflows/coq-windows.yml
 on:
   push:
   pull_request:
 
+env:
+  CHERE_INVOKING: 1
+
 jobs:
   build:
-    name : Cygwin Release - ${{ matrix.arch }}
+    name: Make Cygwin ${{ matrix.arch }} installer
     runs-on: windows-latest
 
     strategy:
       fail-fast: false
       matrix:
-        arch: ["x86", "x86_64"]
+        arch:
+          - x86_64
+          - x86
+        gapbranch:
+          - master
 
     steps:
-    # This sets git to use Linux line endings. While GAP should allow
-    # Windows line endings in GAP files, we currently can't build GAP if the
-    # whole source has Windows line endings
-    - name: Set git to use LF
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
-
     - uses: actions/checkout@v2
 
     - uses: gap-actions/setup-cygwin-for-gap@v1
 
-    # CHERE_INVOKING=1 lets us start a 'login shell' (to set paths) without changing directory
     - name: Compile GAP and download packages
-      run: |
-        @ECHO ON
-        SET CHERE_INVOKING=1
-        C:\cygwin64\bin\bash -l -c 'bash release_gap.sh ARCH=${{ matrix.arch }}'
-      shell: cmd
+      run: bash release_gap.sh ARCH=${{ matrix.arch }} SAGE_VERSION=${{ matrix.gapbranch }}
+      shell: C:\cygwin64\bin\bash.exe --login -o igncr '{0}'
 
     - name: Upload release
       uses: actions/upload-artifact@v2
       with:
-        name: Windows Installer - ${{ matrix.arch }}
+        name: GAP Windows installer - ${{ matrix.arch }}
         path: Output/*

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,16 @@ $(SAGE_CONFIGURE): | $(SAGE_ROOT_BUILD)
 
 $(SAGE_ROOT_BUILD): $(cygwin-build)
 	[ -d $(dir $(SAGE_ROOT_BUILD)) ] || mkdir $(dir $(SAGE_ROOT_BUILD))
-	$(SUBCYG) "$(ENV_BUILD_DIR)" "cd /opt && git clone --single-branch --branch $(SAGE_BRANCH) $(SAGE_GIT) $(SAGE_ROOT)"
+	# Get $(PROG) into the right place.
+	#   If there exists neighbouring directory $(PROG)-$(SAGE_VERSION) e.g.
+	#   gap-4.11.1, then use that version; move into $(SAGE_ROOT_BUILD).
+	#   Else clone into $(SAGE_ROOT) using $(SAGE_GIT) & $(SAGE_BRANCH).
+	# Note that $(SAGE_ROOT) = $(SAGE_ROOT_BUILD)/$(PROG)-$(SAGE_VERSION).
+	if [ -d ../$(PROG)-$(SAGE_VERSION) ]; then \
+		mv ../$(PROG)-$(SAGE_VERSION) $(SAGE_ROOT_BUILD); \
+	else \
+		$(SUBCYG) "$(ENV_BUILD_DIR)" "cd /opt && git clone --single-branch --branch $(SAGE_BRANCH) $(SAGE_GIT) $(SAGE_ROOT)"; \
+	fi
 	# Apply patches
 	if [ -d $(PATCHES)/$(SAGE_BRANCH) ]; then \
 		for patch in $(PATCHES)/$(SAGE_BRANCH)/*.patch; do \

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ all: $(SAGE_INSTALLER)
 
 $(SAGE_INSTALLER): $(SOURCES) $(env-runtime) | $(DIST)
 	cd $(CUDIR)
-	$(ISCC) /DSageName=$(PROG) /DSageVersion=$(SAGE_VERSION) /DSageArch=$(ARCH) \
+	$(ISCC) /DSageName=$(PROG) /DSageVersion=$(SAGE_VERSION) /DSageArch=$(ARCH) /Q \
 		/DInstallerVersion=$(INSTALLER_VERSION) \
 		/DSageTestInstaller=$(SAGE_TEST_INSTALLER) \
 		/DEnvsDir="$(ENVS)" /DOutputDir="$(DIST)" $(SAGEMATH_ISS)

--- a/gap.iss
+++ b/gap.iss
@@ -29,7 +29,7 @@
 
 
 #define MyAppVersion SageVersion
-#define MyAppPublisher "Gap Group"
+#define MyAppPublisher "The GAP Group"
 #define MyAppURL "https://www.gap-system.org"
 #define MyAppExeName "Gap-mintty.bat"
 
@@ -65,7 +65,7 @@ DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-OutputBaseFilename={#MyAppName}-{#MyAppVersion}-{#SageArch}-windows
+OutputBaseFilename=gap-{#MyAppVersion}-{#SageArch}
 Compression=lzma
 LZMANumBlockThreads=6
 SolidCompression=yes

--- a/release_gap.sh
+++ b/release_gap.sh
@@ -1,6 +1,8 @@
+#!/bin/sh
+
 make --trace \
-    SAGE_GIT=https://www.github.com/ChrisJefferson/gap \
-    SAGE_VERSION=cygwin-fixes \
+    SAGE_GIT?=https://github.com/gap-system/gap \
+    SAGE_VERSION?=master \
     SAGE_MAKE_CONFIGURE_CMD?='"cd $(SAGE_ROOT) && ./autogen.sh && ./configure"' \
     SAGE_RUN_CONFIGURE_CMD?='"cd $(SAGE_ROOT) && make && make bootstrap-pkg-full"' \
     SAGE_MAKEFILE='$(SAGE_ROOT_BUILD)/Makefile' \
@@ -9,7 +11,7 @@ make --trace \
     SAGE_BUILD_PACKAGES='"cd $(SAGE_ROOT) && cd pkg && (../bin/BuildPackages.sh --parallel || true)"' \
     SAGE_STARTED='"$(SAGE_ROOT_BUILD)/gap"' \
     SAGE_REBUILD_CMD='"true"' \
-    SAGE_BUILD_DOC_CMD='"cd $(SAGE_ROOT) && make doc"' \
+    SAGE_BUILD_DOC_CMD?='"cd $(SAGE_ROOT) && make doc"' \
     PROGBASE=gap \
     PROG=gap \
     ISCC='"/cygdrive/c/Program Files (x86)/Inno Setup 6/ISCC.exe"' \


### PR DESCRIPTION
I'm making reasonably good progress in my efforts to automate the creation of the Windows installers as part of the GAP release process, as you can see in the GitHub Actions tab of my fork of GAP: https://github.com/wilfwilson/gap/actions/workflows/cygwin_installers.yml

This PR contains the changes that I have found to be either necessary or at least handy for making my automation work.

I'm curious about what you think of my changes, and whether you have any suggestions/whether you want to tell me off for doing anything naughty. The 'naughtiest' thing I did was remove the `make doc` step from your `release_gap.sh` script, because it takes forever, and in practice, I'm going to be using `sage-windows` on a version of GAP whose manuals are already compiled, anyway.

Note that I merged your `cygwin-fixes` branch into `master`, which is why your `release_gap.sh` script can now use `gap-system/gap`, rather than `ChrisJefferson/cygwin-fixes`.